### PR TITLE
Allow to define json_encode options

### DIFF
--- a/Tests/WriterTest.php
+++ b/Tests/WriterTest.php
@@ -37,6 +37,21 @@ class WriterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($data, json_decode($encoded, true), $encoded);
     }
 
+    public function testWriteWithCustomOptions()
+    {
+        $options = JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES;
+
+        $stream = fopen("php://memory", "r+");
+        $writer = new Writer($stream, $options);
+        $writer->write(null, "Les mystérieuses cités d'or");
+
+        rewind($stream);
+        $encoded = stream_get_contents($stream);
+        fclose($stream);
+
+        $this->assertEquals("Les mystérieuses cités d'or", $encoded);
+    }
+
     /**
      * @return array
      */

--- a/Writer.php
+++ b/Writer.php
@@ -30,21 +30,32 @@ class Writer
     const CONTEXT_OBJECT_START = 4;
 
     protected $stream;
+    protected $options;
     protected $context;
 
     protected $parents = array();
 
     /**
      * @param  resource                  $stream A stream resource.
+     * @param  int                       $options JSON encoding options.
      * @throws \InvalidArgumentException If $stream is not a stream resource.
      */
-    public function __construct($stream)
+    public function __construct($stream, $options = null)
     {
         if (!is_resource($stream) || get_resource_type($stream) != 'stream') {
             throw new \InvalidArgumentException("Resource is not a stream");
         }
 
+        if ($options === null) {
+            $options = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT;
+        }
+
+        if (!is_int($options)) {
+            throw new \InvalidArgumentException("Options should be an integer");
+        }
+
         $this->stream  = $stream;
+        $this->options = $options;
         $this->context = self::CONTEXT_NONE;
     }
 
@@ -171,7 +182,7 @@ class Writer
      */
     public function scalar($value)
     {
-        $this->streamWrite(json_encode($value, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT));
+        $this->streamWrite(json_encode($value, $this->options));
 
         return $this;
     }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3"
+        "php": ">=5.3",
+        "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7.0",


### PR DESCRIPTION
This PR allow to define options that's used by the `json_encode` to control the JSON output.